### PR TITLE
Add JSON toggle option for query results

### DIFF
--- a/src/components/Layout/Workspace.module.css
+++ b/src/components/Layout/Workspace.module.css
@@ -84,6 +84,43 @@
     color: var(--text-muted);
 }
 
+.viewToggle {
+    display: flex;
+    background-color: var(--bg-tertiary);
+    border-radius: 4px;
+    padding: 2px;
+    margin-left: 12px;
+}
+
+.toggleButton {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    border: none;
+    border-radius: 3px;
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 11px;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.toggleButton:hover {
+    color: var(--text-primary);
+}
+
+.toggleButtonActive {
+    background-color: var(--bg-secondary);
+    color: var(--accent-primary);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
+.headerLeft {
+    display: flex;
+    align-items: center;
+}
+
 .emptyState {
     display: flex;
     flex-direction: column;

--- a/src/components/Layout/Workspace.tsx
+++ b/src/components/Layout/Workspace.tsx
@@ -3,8 +3,9 @@ import React, { useState } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { SqlEditor } from '../Editor/SqlEditor';
 import { DataGrid } from '../Results/DataGrid';
+import { JsonView } from '../Results/JsonView';
 import { SteamboatLoader } from '../SteamboatLoader';
-import { Play } from 'lucide-react';
+import { Play, Table, FileJson } from 'lucide-react';
 import styles from './Workspace.module.css';
 import { api, type QueryResult } from '../../services/api';
 
@@ -13,6 +14,7 @@ export const Workspace: React.FC = () => {
     const [result, setResult] = useState<QueryResult | null>(null);
     const [loading, setLoading] = useState(false);
     const [hasRun, setHasRun] = useState(false);
+    const [viewMode, setViewMode] = useState<'table' | 'json'>('table');
 
     const handleRunQuery = async () => {
         if (!query.trim()) return;
@@ -56,7 +58,29 @@ export const Workspace: React.FC = () => {
                     <Panel defaultSize={50} minSize={20}>
                         <div className={styles.resultsArea}>
                             <div className={styles.resultsHeader}>
-                                <span>Query Results</span>
+                                <div className={styles.headerLeft}>
+                                    <span>Query Results</span>
+                                    {result?.data && (
+                                        <div className={styles.viewToggle}>
+                                            <button
+                                                className={`${styles.toggleButton} ${viewMode === 'table' ? styles.toggleButtonActive : ''}`}
+                                                onClick={() => setViewMode('table')}
+                                                title="Table View"
+                                            >
+                                                <Table size={12} />
+                                                <span>Table</span>
+                                            </button>
+                                            <button
+                                                className={`${styles.toggleButton} ${viewMode === 'json' ? styles.toggleButtonActive : ''}`}
+                                                onClick={() => setViewMode('json')}
+                                                title="JSON View"
+                                            >
+                                                <FileJson size={12} />
+                                                <span>JSON</span>
+                                            </button>
+                                        </div>
+                                    )}
+                                </div>
                                 {result?.data && (
                                     <span className={styles.meta}>
                                         {result.data.length} rows retrieved
@@ -87,7 +111,11 @@ export const Workspace: React.FC = () => {
                             )}
 
                             {hasRun && !loading && result?.data && result.schema && (
-                                <DataGrid columns={result.schema} data={result.data} />
+                                viewMode === 'table' ? (
+                                    <DataGrid columns={result.schema} data={result.data} />
+                                ) : (
+                                    <JsonView data={result.data} />
+                                )
                             )}
                         </div>
                     </Panel>

--- a/src/components/Results/DataGrid.tsx
+++ b/src/components/Results/DataGrid.tsx
@@ -8,7 +8,7 @@ interface Column {
 
 interface DataGridProps {
     columns: Column[];
-    data: any[];
+    data: Record<string, unknown>[];
 }
 
 export const DataGrid: React.FC<DataGridProps> = ({ columns, data }) => {
@@ -32,7 +32,9 @@ export const DataGrid: React.FC<DataGridProps> = ({ columns, data }) => {
                         <tr key={i}>
                             {columns.map((col) => (
                                 <td key={`${i}-${col.name}`}>
-                                    {row[col.name]}
+                                    {typeof row[col.name] === 'object' && row[col.name] !== null
+                                        ? JSON.stringify(row[col.name])
+                                        : String(row[col.name] ?? '')}
                                 </td>
                             ))}
                         </tr>

--- a/src/components/Results/JsonView.module.css
+++ b/src/components/Results/JsonView.module.css
@@ -1,0 +1,5 @@
+.container {
+    height: 100%;
+    width: 100%;
+    background-color: var(--bg-primary);
+}

--- a/src/components/Results/JsonView.tsx
+++ b/src/components/Results/JsonView.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import Editor from '@monaco-editor/react';
+import styles from './JsonView.module.css';
+
+interface JsonViewProps {
+    data: unknown[];
+}
+
+export const JsonView: React.FC<JsonViewProps> = ({ data }) => {
+    const jsonString = JSON.stringify(data, null, 2);
+
+    return (
+        <div className={styles.container}>
+            <Editor
+                height="100%"
+                defaultLanguage="json"
+                value={jsonString}
+                theme="spark-dark"
+                options={{
+                    readOnly: true,
+                    minimap: { enabled: false },
+                    fontSize: 13,
+                    fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
+                    scrollBeyondLastLine: false,
+                    automaticLayout: true,
+                    folding: true,
+                    lineNumbers: 'on',
+                    wordWrap: 'on',
+                }}
+            />
+        </div>
+    );
+};


### PR DESCRIPTION
This change introduces a JSON toggle option for query results, allowing users to view data in a pretty-printed, collapsible JSON format. This is particularly useful for dataframes with multiple nested columns.

Key changes:
- `DataGrid.tsx`: Cells with object values are now stringified instead of causing React rendering errors.
- `JsonView.tsx`: A new component that renders the result data as JSON using Monaco Editor, providing features like folding and syntax highlighting.
- `Workspace.tsx`: Added state to toggle between 'table' and 'json' views, and added the corresponding UI controls in the results header.
- `Workspace.module.css`: Added styles for the toggle buttons.

Fixes #3

---
*PR created automatically by Jules for task [11046589490127261898](https://jules.google.com/task/11046589490127261898) started by @Cbeaucl*