### PR TITLE
Secure: Prevent detailed error information disclosure in API responses

### DIFF
--- a/secondmate/main.py
+++ b/secondmate/main.py
@@ -3,6 +3,7 @@ from pyspark.sql import SparkSession
 from secondmate.dependencies import get_spark_session
 import sys
 import os
+import logging
 from pydantic import BaseModel
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse, HTMLResponse
@@ -21,6 +22,8 @@ def validate_identifier(name: str):
     """Validate that an identifier only contains alphanumeric characters, underscores, and dots."""
     if not re.match(r"^[a-zA-Z0-9_.]+$", name):
         raise HTTPException(status_code=400, detail=f"Invalid identifier: {name}")
+
+logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -105,10 +108,9 @@ def execute_query(request: QueryRequest, spark: SparkSession = Depends(get_spark
         data = [row.asDict() for row in df.collect()]
         
         return {"schema": schema, "data": data}
-    except Exception as e:
-        import traceback
-        traceback.print_exc()
-        return {"error": str(e)}
+    except Exception:
+        logger.error("Error executing query", exc_info=True)
+        return {"error": "An error occurred while executing the query."}
 
 @router.get("/catalogs")
 def get_catalogs(spark: SparkSession = Depends(get_spark_session)):
@@ -121,8 +123,9 @@ def get_catalogs(spark: SparkSession = Depends(get_spark_session)):
         df = spark.sql("SHOW CATALOGS")
         catalogs = [row.catalog for row in df.collect()]
         return {"catalogs": catalogs}
-    except Exception as e:
-        return {"catalogs": [], "error": str(e)}
+    except Exception:
+        logger.error("Error retrieving catalogs", exc_info=True)
+        return {"catalogs": [], "error": "Unable to retrieve catalogs."}
 
 @router.get("/catalogs/{catalog_name}/namespaces")
 def get_namespaces(catalog_name: str, spark: SparkSession = Depends(get_spark_session)):
@@ -134,8 +137,9 @@ def get_namespaces(catalog_name: str, spark: SparkSession = Depends(get_spark_se
         # The column name is usually 'namespace'
         namespaces = [row.namespace for row in df.collect()]
         return {"namespaces": namespaces}
-    except Exception as e:
-        return {"namespaces": [], "error": str(e)}
+    except Exception:
+        logger.error(f"Error retrieving namespaces for catalog {catalog_name}", exc_info=True)
+        return {"namespaces": [], "error": "Unable to retrieve namespaces."}
 
 @router.get("/catalogs/{catalog_name}/namespaces/{namespace}/tables")
 def get_tables(catalog_name: str, namespace: str, spark: SparkSession = Depends(get_spark_session)):
@@ -147,8 +151,9 @@ def get_tables(catalog_name: str, namespace: str, spark: SparkSession = Depends(
         # Columns: 'namespace', 'tableName', 'isTemporary'
         tables = [row.tableName for row in df.collect()]
         return {"tables": tables}
-    except Exception as e:
-        return {"tables": [], "error": str(e)}
+    except Exception:
+        logger.error(f"Error retrieving tables for {catalog_name}.{namespace}", exc_info=True)
+        return {"tables": [], "error": "Unable to retrieve tables."}
 
 @router.get("/info")
 def get_info(spark: SparkSession = Depends(get_spark_session)):
@@ -208,8 +213,9 @@ def search_catalog(q: str, spark: SparkSession = Depends(get_spark_session)):
             except Exception:
                 continue
 
-    except Exception as e:
-        return {"results": [], "error": str(e)}
+    except Exception:
+        logger.error("Error during catalog search", exc_info=True)
+        return {"results": [], "error": "An error occurred during search."}
 
     return {"results": results}
 

--- a/tests/test_security_fixes.py
+++ b/tests/test_security_fixes.py
@@ -1,0 +1,59 @@
+
+import unittest
+from unittest.mock import MagicMock
+from secondmate.main import execute_query, get_catalogs, get_namespaces, get_tables, search_catalog, QueryRequest
+
+class TestSecurityFixes(unittest.TestCase):
+    def setUp(self):
+        self.mock_spark = MagicMock()
+        self.sensitive_info = "Sensitive Path: /etc/passwd"
+        self.exception = Exception(f"Database error: {self.sensitive_info}")
+
+    def test_execute_query_secure(self):
+        self.mock_spark.sql.side_effect = self.exception
+        request = QueryRequest(query="SELECT * FROM users")
+
+        response = execute_query(request, spark=self.mock_spark)
+
+        self.assertIn("error", response)
+        self.assertEqual(response["error"], "An error occurred while executing the query.")
+        self.assertNotIn(self.sensitive_info, response["error"])
+
+    def test_get_catalogs_secure(self):
+        self.mock_spark.sql.side_effect = self.exception
+
+        response = get_catalogs(spark=self.mock_spark)
+
+        self.assertIn("error", response)
+        self.assertEqual(response["error"], "Unable to retrieve catalogs.")
+        self.assertNotIn(self.sensitive_info, response["error"])
+
+    def test_get_namespaces_secure(self):
+        self.mock_spark.sql.side_effect = self.exception
+
+        response = get_namespaces("test_catalog", spark=self.mock_spark)
+
+        self.assertIn("error", response)
+        self.assertEqual(response["error"], "Unable to retrieve namespaces.")
+        self.assertNotIn(self.sensitive_info, response["error"])
+
+    def test_get_tables_secure(self):
+        self.mock_spark.sql.side_effect = self.exception
+
+        response = get_tables("test_catalog", "test_namespace", spark=self.mock_spark)
+
+        self.assertIn("error", response)
+        self.assertEqual(response["error"], "Unable to retrieve tables.")
+        self.assertNotIn(self.sensitive_info, response["error"])
+
+    def test_search_catalog_secure(self):
+        self.mock_spark.sql.side_effect = self.exception
+
+        response = search_catalog("search_term", spark=self.mock_spark)
+
+        self.assertIn("error", response)
+        self.assertEqual(response["error"], "An error occurred during search.")
+        self.assertNotIn(self.sensitive_info, response["error"])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixed a security vulnerability where detailed exception messages (including stack traces and internal paths) were returned to the API client.

Changes:
- Replaced `traceback.print_exc()` with `logging.error(..., exc_info=True)` in `secondmate/main.py`.
- Updated `execute_query`, `get_catalogs`, `get_namespaces`, `get_tables`, and `search_catalog` endpoints to return generic error messages instead of raw exception strings.
- Added `tests/test_security_fixes.py` to verify that sensitive information is not leaked in error responses.

This prevents potential information leakage about the backend environment and database schema.

---
*PR created automatically by Jules for task [3883922248574455986](https://jules.google.com/task/3883922248574455986) started by @Cbeaucl*