### PR TITLE
Add Iceberg Table Overview Feature

### DIFF
--- a/secondmate/main.py
+++ b/secondmate/main.py
@@ -155,6 +155,76 @@ def get_tables(catalog_name: str, namespace: str, spark: SparkSession = Depends(
         logger.error(f"Error retrieving tables for {catalog_name}.{namespace}", exc_info=True)
         return {"tables": [], "error": "Unable to retrieve tables."}
 
+@router.get("/catalogs/{catalog_name}/namespaces/{namespace}/tables/{table_name}/overview")
+def get_table_overview(catalog_name: str, namespace: str, table_name: str, spark: SparkSession = Depends(get_spark_session)):
+    """Get an overview of an Iceberg table including schema, properties, snapshots, partitions, and files."""
+    validate_identifier(catalog_name)
+    validate_identifier(namespace)
+    validate_identifier(table_name)
+
+    full_table_name = f"{catalog_name}.{namespace}.{table_name}"
+
+    try:
+        # 1. Schema
+        df = spark.table(full_table_name)
+        schema_json = df.schema.jsonValue()
+
+        # Helper to get data from metadata tables or return empty list if not supported
+        def get_metadata(suffix, query=None):
+            try:
+                if query:
+                    m_df = spark.sql(query)
+                else:
+                    m_df = spark.sql(f"SELECT * FROM {full_table_name}.{suffix}")
+                return [row.asDict() for row in m_df.collect()]
+            except Exception as e:
+                logger.warning(f"Metadata table {suffix} not available for {full_table_name}: {e}")
+                return []
+
+        # 2. Properties
+        properties = get_metadata("properties")
+
+        # 3. Snapshots (ordered by latest, limit 250)
+        snapshots = get_metadata("snapshots", f"SELECT * FROM {full_table_name}.snapshots ORDER BY committed_at DESC LIMIT 250")
+
+        # 4. Partitions (limit 250)
+        partitions = get_metadata("partitions", f"SELECT * FROM {full_table_name}.partitions LIMIT 250")
+
+        # 5. Files (exclude file_path, convert size to MB, limit 250)
+        files = get_metadata("files", f"""
+            SELECT
+                content,
+                file_format,
+                spec_id,
+                partition,
+                record_count,
+                file_size_in_bytes / (1024.0 * 1024.0) as file_size_mb,
+                column_sizes,
+                value_counts,
+                null_value_counts,
+                nan_value_counts,
+                lower_bounds,
+                upper_bounds,
+                key_metadata,
+                split_offsets,
+                equality_ids,
+                sort_order_id
+            FROM {full_table_name}.files
+            LIMIT 250
+        """)
+
+        return {
+            "tableName": full_table_name,
+            "schema": schema_json,
+            "properties": properties,
+            "snapshots": snapshots,
+            "partitions": partitions,
+            "files": files
+        }
+    except Exception:
+        logger.error(f"Error retrieving overview for {full_table_name}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Unable to retrieve overview for table {full_table_name}")
+
 @router.get("/info")
 def get_info(spark: SparkSession = Depends(get_spark_session)):
     return {

--- a/src/components/Layout/MainLayout.tsx
+++ b/src/components/Layout/MainLayout.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { Sidebar } from './Sidebar';
+import { TableOverview } from './TableOverview';
 import { api, type SystemInfo } from '../../services/api';
 import styles from './MainLayout.module.css';
 
@@ -11,6 +12,7 @@ interface MainLayoutProps {
 export const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
   const [systemInfo, setSystemInfo] = React.useState<SystemInfo | null>(null);
   const [error, setError] = React.useState<string | null>(null);
+  const [overviewTable, setOverviewTable] = React.useState<{ catalog: string, namespace: string, table: string } | null>(null);
 
   React.useEffect(() => {
     const fetchInfo = async () => {
@@ -33,13 +35,23 @@ export const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
     <div className={styles.container}>
       <PanelGroup direction="horizontal">
         <Panel defaultSize={20} minSize={15} maxSize={40} className={styles.sidebarPanel}>
-          <Sidebar />
+          <Sidebar onTableOverview={(catalog, namespace, table) => setOverviewTable({ catalog, namespace, table })} />
         </Panel>
         <PanelResizeHandle className={styles.resizeHandle} />
         <Panel className={styles.contentPanel}>
           {children}
         </Panel>
       </PanelGroup>
+
+      {overviewTable && (
+        <TableOverview
+          catalog={overviewTable.catalog}
+          namespace={overviewTable.namespace}
+          table={overviewTable.table}
+          onClose={() => setOverviewTable(null)}
+        />
+      )}
+
       <div className={styles.statusBar}>
         <span>Ready</span>
         {error ? (

--- a/src/components/Layout/Sidebar.module.css
+++ b/src/components/Layout/Sidebar.module.css
@@ -103,6 +103,54 @@
     color: var(--text-primary);
 }
 
+.treeRow:hover .moreButton {
+    opacity: 1;
+}
+
+.moreButton {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    padding: 2px;
+    border-radius: 4px;
+    opacity: 0;
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.moreButton:hover {
+    background-color: var(--bg-primary);
+    color: var(--text-primary);
+}
+
+.menu {
+    position: fixed;
+    background-color: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    padding: 4px 0;
+    z-index: 1000;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    min-width: 140px;
+}
+
+.menuItem {
+    padding: 6px 12px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--text-secondary);
+}
+
+.menuItem:hover {
+    background-color: var(--bg-tertiary);
+    color: var(--text-primary);
+}
+
 .treeChildren {
     padding-left: 16px;
 }

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -1,22 +1,49 @@
 import React, { useEffect, useState } from 'react';
-import { Database, Table, Folder, ChevronRight, ChevronDown, Search, Loader2, X } from 'lucide-react';
+import { Database, Table, Folder, ChevronRight, ChevronDown, Search, Loader2, X, MoreVertical, FileText } from 'lucide-react';
 import styles from './Sidebar.module.css';
 import { api } from '../../services/api';
 
 interface TreeNodeProps {
     label: string;
     type: 'catalog' | 'namespace' | 'table';
+    catalog?: string;
+    namespace?: string;
     children?: React.ReactNode;
     isExpanded?: boolean;
     onToggle?: () => void;
     isLoading?: boolean;
     forceExpand?: boolean;
+    onTableOverview?: (catalog: string, namespace: string, table: string) => void;
 }
 
-const TreeNode: React.FC<TreeNodeProps> = ({ label, type, children, isExpanded, onToggle, isLoading, forceExpand }) => {
+const TreeNode: React.FC<TreeNodeProps> = ({
+    label,
+    type,
+    catalog,
+    namespace,
+    children,
+    isExpanded,
+    onToggle,
+    isLoading,
+    forceExpand,
+    onTableOverview
+}) => {
     const Icon = type === 'catalog' ? Database : type === 'namespace' ? Folder : Table;
     const color = type === 'catalog' ? '#38bdf8' : type === 'namespace' ? '#fbbf24' : '#a78bfa';
     const showChildren = forceExpand || isExpanded;
+    const [menuOpen, setMenuOpen] = useState<{ x: number, y: number } | null>(null);
+
+    const handleMoreClick = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        setMenuOpen({ x: e.clientX, y: e.clientY });
+    };
+
+    useEffect(() => {
+        if (!menuOpen) return;
+        const closeMenu = () => setMenuOpen(null);
+        window.addEventListener('click', closeMenu);
+        return () => window.removeEventListener('click', closeMenu);
+    }, [menuOpen]);
 
     return (
         <div className={styles.treeItem}>
@@ -30,13 +57,40 @@ const TreeNode: React.FC<TreeNodeProps> = ({ label, type, children, isExpanded, 
                 {type === 'table' && <div style={{ width: 16 }} />}
                 <Icon size={14} className={styles.icon} color={color} />
                 <span className="truncate">{label}</span>
+                {type === 'table' && onTableOverview && catalog && namespace && (
+                    <button className={styles.moreButton} onClick={handleMoreClick}>
+                        <MoreVertical size={14} />
+                    </button>
+                )}
             </div>
+            {menuOpen && (
+                <div
+                    className={styles.menu}
+                    style={{ top: menuOpen.y, left: menuOpen.x }}
+                    onClick={(e) => e.stopPropagation()}
+                >
+                    <div
+                        className={styles.menuItem}
+                        onClick={() => {
+                            onTableOverview?.(catalog!, namespace!, label);
+                            setMenuOpen(null);
+                        }}
+                    >
+                        <FileText size={14} />
+                        <span>Table Overview</span>
+                    </div>
+                </div>
+            )}
             {showChildren && children && <div className={styles.treeChildren}>{children}</div>}
         </div>
     );
 };
 
-export const Sidebar: React.FC = () => {
+interface SidebarProps {
+    onTableOverview?: (catalog: string, namespace: string, table: string) => void;
+}
+
+export const Sidebar: React.FC<SidebarProps> = ({ onTableOverview }) => {
     const [catalogs, setCatalogs] = useState<string[]>([]);
     const [expandedCatalogs, setExpandedCatalogs] = useState<Record<string, boolean>>({});
     const [namespaces, setNamespaces] = useState<Record<string, string[]>>({});
@@ -188,6 +242,9 @@ export const Sidebar: React.FC = () => {
                                             key={table}
                                             label={table}
                                             type="table"
+                                            catalog={catalog}
+                                            namespace={ns}
+                                            onTableOverview={onTableOverview}
                                         />
                                     ))}
                                 </TreeNode>
@@ -217,6 +274,19 @@ export const Sidebar: React.FC = () => {
                                     {item.type === 'namespace' && `${item.catalog}.${item.namespace}`}
                                     {item.type === 'table' && `${item.catalog}.${item.namespace}.${item.table}`}
                                 </span>
+
+                                {item.type === 'table' && onTableOverview && (
+                                    <button
+                                        className={styles.moreButton}
+                                        onClick={(e) => {
+                                            e.stopPropagation();
+                                            onTableOverview(item.catalog, item.namespace, item.table);
+                                        }}
+                                        title="Table Overview"
+                                    >
+                                        <MoreVertical size={14} />
+                                    </button>
+                                )}
                             </div>
                         ))}
                     </>

--- a/src/components/Layout/TableOverview.module.css
+++ b/src/components/Layout/TableOverview.module.css
@@ -1,0 +1,139 @@
+.overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.7);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+    backdrop-filter: blur(4px);
+}
+
+.modal {
+    background-color: var(--bg-primary);
+    width: 90%;
+    height: 90%;
+    max-width: 1200px;
+    border-radius: 8px;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    border: 1px solid var(--border-color);
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+}
+
+.header {
+    padding: 16px 24px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid var(--border-color);
+    background-color: var(--bg-secondary);
+}
+
+.titleGroup h1 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.tableName {
+    font-size: 0.875rem;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+}
+
+.closeButton {
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 4px;
+    transition: background-color 0.2s;
+}
+
+.closeButton:hover {
+    background-color: var(--bg-tertiary);
+    color: var(--text-primary);
+}
+
+.content {
+    flex: 1;
+    overflow-y: auto;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+}
+
+.section h2 {
+    margin: 0 0 16px 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--accent-primary);
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 8px;
+}
+
+.sectionHeader {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    margin-bottom: 16px;
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 8px;
+}
+
+.sectionHeader h2 {
+    margin: 0;
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.jsonWrapper {
+    height: 300px;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.emptyText {
+    color: var(--text-muted);
+    font-style: italic;
+    font-size: 0.875rem;
+}
+
+.loadingContainer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    gap: 16px;
+    color: var(--text-secondary);
+}
+
+.spinner {
+    animation: spin 1s linear infinite;
+    width: 32px;
+    height: 32px;
+}
+
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+.errorText {
+    color: #ef4444;
+    padding: 16px;
+    background-color: rgba(239, 68, 68, 0.1);
+    border-radius: 4px;
+    border: 1px solid rgba(239, 68, 68, 0.2);
+}

--- a/src/components/Layout/TableOverview.tsx
+++ b/src/components/Layout/TableOverview.tsx
@@ -1,0 +1,146 @@
+import React, { useState, useEffect } from 'react';
+import { X, ChevronDown, ChevronRight, Loader2 } from 'lucide-react';
+import { JsonView } from '../Results/JsonView';
+import { DataGrid } from '../Results/DataGrid';
+import { api } from '../../services/api';
+import styles from './TableOverview.module.css';
+
+interface TableOverviewProps {
+    catalog: string;
+    namespace: string;
+    table: string;
+    onClose: () => void;
+}
+
+export const TableOverview: React.FC<TableOverviewProps> = ({ catalog, namespace, table, onClose }) => {
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [overviewData, setOverviewData] = useState<any>(null);
+    const [schemaExpanded, setSchemaExpanded] = useState(true);
+
+    useEffect(() => {
+        const fetchOverview = async () => {
+            setLoading(true);
+            try {
+                const data = await api.getTableOverview(catalog, namespace, table);
+                setOverviewData(data);
+            } catch (err: any) {
+                setError(err.message || 'Failed to fetch table overview');
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchOverview();
+    }, [catalog, namespace, table]);
+
+    if (loading) {
+        return (
+            <div className={styles.overlay}>
+                <div className={styles.modal}>
+                    <div className={styles.loadingContainer}>
+                        <Loader2 className={styles.spinner} />
+                        <span>Loading Table Overview...</span>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className={styles.overlay}>
+                <div className={styles.modal}>
+                    <div className={styles.header}>
+                        <h2>Error</h2>
+                        <button onClick={onClose} className={styles.closeButton}><X size={20} /></button>
+                    </div>
+                    <div className={styles.content}>
+                        <p className={styles.errorText}>{error}</p>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    const { tableName, schema, properties, snapshots, partitions, files } = overviewData;
+
+    // Helper to get columns for DataGrid
+    const getColumns = (data: any[]) => {
+        if (!data || data.length === 0) return [];
+        return Object.keys(data[0]).map(key => ({ name: key, type: typeof data[0][key] }));
+    };
+
+    // Flatten partitions for display
+    const flattenedPartitions = partitions.map((p: any) => {
+        const { partition, ...rest } = p;
+        if (partition && typeof partition === 'object') {
+            return { ...rest, ...partition };
+        }
+        return p;
+    });
+
+    return (
+        <div className={styles.overlay}>
+            <div className={styles.modal}>
+                <div className={styles.header}>
+                    <div className={styles.titleGroup}>
+                        <h1>Table Overview</h1>
+                        <span className={styles.tableName}>{tableName}</span>
+                    </div>
+                    <button onClick={onClose} className={styles.closeButton}><X size={20} /></button>
+                </div>
+
+                <div className={styles.content}>
+                    <section className={styles.section}>
+                        <div className={styles.sectionHeader} onClick={() => setSchemaExpanded(!schemaExpanded)}>
+                            {schemaExpanded ? <ChevronDown size={18} /> : <ChevronRight size={18} />}
+                            <h2>Schema</h2>
+                        </div>
+                        {schemaExpanded && (
+                            <div className={styles.jsonWrapper}>
+                                <JsonView data={schema} />
+                            </div>
+                        )}
+                    </section>
+
+                    <section className={styles.section}>
+                        <h2>Table Properties</h2>
+                        {properties.length > 0 ? (
+                            <DataGrid columns={getColumns(properties)} data={properties} />
+                        ) : (
+                            <p className={styles.emptyText}>No properties found.</p>
+                        )}
+                    </section>
+
+                    <section className={styles.section}>
+                        <h2>Iceberg Snapshots</h2>
+                        {snapshots.length > 0 ? (
+                            <DataGrid columns={getColumns(snapshots)} data={snapshots} />
+                        ) : (
+                            <p className={styles.emptyText}>No snapshots found.</p>
+                        )}
+                    </section>
+
+                    <section className={styles.section}>
+                        <h2>Iceberg Partitions</h2>
+                        {flattenedPartitions.length > 0 ? (
+                            <DataGrid columns={getColumns(flattenedPartitions)} data={flattenedPartitions} />
+                        ) : (
+                            <p className={styles.emptyText}>No partitions found.</p>
+                        )}
+                    </section>
+
+                    <section className={styles.section}>
+                        <h2>Iceberg Files</h2>
+                        {files.length > 0 ? (
+                            <DataGrid columns={getColumns(files)} data={files} />
+                        ) : (
+                            <p className={styles.emptyText}>No files found.</p>
+                        )}
+                    </section>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -72,6 +72,12 @@ export const api = {
         const response = await fetch(`${API_BASE_URL}/info`);
         if (!response.ok) throw new Error('Failed to fetch system info');
         return await response.json();
+    },
+
+    getTableOverview: async (catalogName: string, namespace: string, tableName: string): Promise<any> => {
+        const response = await fetch(`${API_BASE_URL}/catalogs/${catalogName}/namespaces/${namespace}/tables/${tableName}/overview`);
+        if (!response.ok) throw new Error('Failed to fetch table overview');
+        return await response.json();
     }
 };
 


### PR DESCRIPTION
This PR adds a comprehensive Table Overview feature for Iceberg tables in SecondMate. Users can now view a report-style overview of any table by clicking the "Table Overview" option in the table's context menu in the sidebar. The overview includes:
- Table Name
- Collapsible JSON Schema (using Monaco Editor)
- Table Properties
- Iceberg Snapshots (latest 250)
- Iceberg Partitions (latest 250, with flattened partition columns)
- Iceberg Files (latest 250, sizes in MB, file paths hidden)

The backend uses Spark SQL metadata tables to retrieve this information, with robust error handling to gracefully handle cases where certain metadata tables might not be supported or available.

Fixes #20

---
*PR created automatically by Jules for task [16015824042455238148](https://jules.google.com/task/16015824042455238148) started by @Cbeaucl*