### PR TITLE
Fix nested PySpark struct parsing in API results

### DIFF
--- a/secondmate/main.py
+++ b/secondmate/main.py
@@ -105,7 +105,7 @@ def execute_query(request: QueryRequest, spark: SparkSession = Depends(get_spark
         schema = [{"name": field.name, "type": str(field.dataType)} for field in df.schema.fields]
         
         # Get data
-        data = [row.asDict() for row in df.collect()]
+        data = [row.asDict(recursive=True) for row in df.collect()]
         
         return {"schema": schema, "data": data}
     except Exception:
@@ -176,7 +176,7 @@ def get_table_overview(catalog_name: str, namespace: str, table_name: str, spark
                     m_df = spark.sql(query)
                 else:
                     m_df = spark.sql(f"SELECT * FROM {full_table_name}.{suffix}")
-                return [row.asDict() for row in m_df.collect()]
+                return [row.asDict(recursive=True) for row in m_df.collect()]
             except Exception as e:
                 logger.warning(f"Metadata table {suffix} not available for {full_table_name}: {e}")
                 return []

--- a/tests/test_api_nested_structs.py
+++ b/tests/test_api_nested_structs.py
@@ -1,0 +1,63 @@
+import unittest
+from unittest.mock import MagicMock
+from pyspark.sql import Row
+from pyspark.sql.types import StructType, StructField, StringType, IntegerType
+from secondmate.main import execute_query, QueryRequest
+
+class TestApiNestedStructs(unittest.TestCase):
+    def test_execute_query_with_nested_structs(self):
+        # Setup mock spark and dataframe
+        mock_spark = MagicMock()
+        mock_df = MagicMock()
+        mock_spark.sql.return_value = mock_df
+        mock_df.limit.return_value = mock_df
+
+        # Mock schema
+        mock_field1 = MagicMock()
+        mock_field1.name = "id"
+        mock_field1.dataType = IntegerType()
+
+        mock_field2 = MagicMock()
+        mock_field2.name = "nested"
+        mock_field2.dataType = StructType([
+            StructField("inner_str", StringType()),
+            StructField("inner_nested", StructType([
+                StructField("val", IntegerType())
+            ]))
+        ])
+
+        mock_schema = MagicMock()
+        mock_schema.fields = [mock_field1, mock_field2]
+        mock_df.schema = mock_schema
+
+        # Mock data with nested Rows
+        row1 = Row(
+            id=1,
+            nested=Row(
+                inner_str="test",
+                inner_nested=Row(val=42)
+            )
+        )
+        mock_df.collect.return_value = [row1]
+
+        # Execute request
+        request = QueryRequest(query="SELECT * FROM test_table")
+        response = execute_query(request, spark=mock_spark)
+
+        # Verify schema is correct (stringified types for JSON serialization)
+        self.assertEqual(len(response["schema"]), 2)
+        self.assertEqual(response["schema"][0]["name"], "id")
+        self.assertEqual(response["schema"][1]["name"], "nested")
+
+        # Verify data is parsed recursively to pure dicts
+        self.assertEqual(len(response["data"]), 1)
+        data = response["data"][0]
+
+        self.assertEqual(data["id"], 1)
+        self.assertIsInstance(data["nested"], dict)
+        self.assertEqual(data["nested"]["inner_str"], "test")
+        self.assertIsInstance(data["nested"]["inner_nested"], dict)
+        self.assertEqual(data["nested"]["inner_nested"]["val"], 42)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes an issue where nested structs in query results and table metadata were not fully parsed, remaining as stringified PySpark `Row` objects rather than properly recursive JSON structures. Using `.asDict(recursive=True)` properly maps all inner elements into native Python dicts.

Added new tests in `tests/test_api_nested_structs.py` to assert this correct nested behavior.

---
*PR created automatically by Jules for task [13296583910653606395](https://jules.google.com/task/13296583910653606395) started by @Cbeaucl*