### PR TITLE
🧪 Add test coverage for missing class attribute in custom Spark provider

### DIFF
--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -43,6 +43,14 @@ class TestSparkProvider(unittest.TestCase):
             mock_provider_class.assert_called_once()
             self.assertEqual(provider, mock_provider_instance)
 
+    def test_custom_provider_attribute_error(self):
+        """Test that ImportError is raised if the class cannot be found in the module."""
+        with patch.dict(os.environ, {"SPARK_PROVIDER_CLASS": "os.FakeProviderClass"}):
+            with self.assertRaises(ImportError) as cm:
+                get_spark_provider()
+
+            self.assertIn("Could not load Spark provider 'os.FakeProviderClass'", str(cm.exception))
+
     def test_custom_provider_import_error(self):
         """Test that ImportError is raised if the module cannot be imported."""
         with patch.dict(os.environ, {"SPARK_PROVIDER_CLASS": "invalid.module.Provider"}), \


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses a missing test case in `tests/test_dependencies.py` for the `get_spark_provider()` function. Specifically, it tests the `AttributeError` scenario that occurs when an invalid class name is provided within a valid module for the `SPARK_PROVIDER_CLASS` environment variable.

📊 **Coverage:** What scenarios are now tested
The `AttributeError` scenario is now explicitly tested. The test sets `SPARK_PROVIDER_CLASS` to a string like `"os.FakeClass"` (where the module `os` exists, but the class `FakeClass` does not) and verifies that an `ImportError` containing a descriptive message is raised, matching the behavior of the exception handling block in `dependencies.py`.

✨ **Result:** The improvement in test coverage
Test coverage for the `get_spark_provider` dependency is now comprehensive, covering `ImportError`, `ValueError`, and `AttributeError` failure modes when loading custom Spark providers via environment variables.

---
*PR created automatically by Jules for task [13525236829962159512](https://jules.google.com/task/13525236829962159512) started by @Cbeaucl*