### PR TITLE
Spark Provider Dynamic Configuration UI & API

### DIFF
--- a/secondmate/main.py
+++ b/secondmate/main.py
@@ -17,6 +17,8 @@ from secondmate.dependencies import get_spark_provider
 
 from secondmate.providers.local_spark import LocalSparkProvider
 from secondmate.dev_data import initialize_dev_data
+from secondmate.models import ConfigOption
+from typing import Dict, Any, List
 import re
 import base64
 
@@ -61,9 +63,16 @@ class QueryRequest(BaseModel):
     query: str
 
 @router.post("/query/execute")
-def execute_query(request: QueryRequest, spark: SparkSession = Depends(get_spark_session)):
+def execute_query(request: QueryRequest, provider = Depends(get_spark_provider)):
     """Execute a raw SQL query and return results."""
+    # Validate required configs
+    configs = provider.get_configs()
+    for config in configs:
+        if config.is_required and (config.current_value is None or config.current_value == ""):
+            raise HTTPException(status_code=400, detail=f"Required configuration '{config.label}' is missing.")
+
     try:
+        spark = provider.get_session()
         df = spark.sql(request.query)
         # Limit to 1000 to prevent overloading
         df = df.limit(1000)
@@ -193,6 +202,21 @@ def get_table_overview(catalog_name: str, namespace: str, table_name: str, spark
     except Exception:
         logger.error(f"Error retrieving overview for {full_table_name}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Unable to retrieve overview for table {full_table_name}")
+
+@router.get("/configs", response_model=List[ConfigOption])
+def get_configs(provider=Depends(get_spark_provider)):
+    """Get the current configurations."""
+    return provider.get_configs()
+
+@router.post("/configs")
+def set_configs(configs: Dict[str, Any], provider=Depends(get_spark_provider)):
+    """Update the configurations."""
+    try:
+        provider.set_configs(configs)
+        return {"status": "ok"}
+    except Exception as e:
+        logger.error("Error updating configurations", exc_info=True)
+        raise HTTPException(status_code=422, detail=str(e))
 
 @router.get("/info")
 def get_info(spark: SparkSession = Depends(get_spark_session)):

--- a/secondmate/models.py
+++ b/secondmate/models.py
@@ -1,0 +1,28 @@
+from enum import Enum
+from typing import List, Any, Optional, Dict
+from pydantic import BaseModel
+
+class DataType(str, Enum):
+    STRING = "string"
+    INTEGER = "integer"
+    BOOLEAN = "boolean"
+
+class UiInputType(str, Enum):
+    TEXT = "text"
+    SELECT = "select"
+    RADIO = "radio"
+    TOGGLE = "toggle"
+
+class ConfigOptionItem(BaseModel):
+    label: str
+    value: Any
+
+class ConfigOption(BaseModel):
+    id: str
+    label: str
+    data_type: DataType
+    ui_input_type: UiInputType
+    current_value: Optional[Any] = None
+    default_value: Optional[Any] = None
+    options: Optional[List[ConfigOptionItem]] = None
+    is_required: bool = False

--- a/secondmate/providers/local_spark.py
+++ b/secondmate/providers/local_spark.py
@@ -1,14 +1,45 @@
+from typing import List, Dict, Any
 from pyspark.sql import SparkSession
 from secondmate.providers.spark_interface import SparkProvider
+from secondmate.models import ConfigOption, DataType, UiInputType, ConfigOptionItem
 
 class LocalSparkProvider(SparkProvider):
     def __init__(self, app_name: str = "SecondMateLocal"):
         self.app_name = app_name
         self._session = None
+        self._configs = {
+            "spark.executor.memory": ConfigOption(
+                id="spark.executor.memory",
+                label="Executor Memory",
+                data_type=DataType.STRING,
+                ui_input_type=UiInputType.TEXT,
+                current_value="1g",
+                default_value="1g",
+                is_required=True
+            ),
+            "spark.driver.memory": ConfigOption(
+                id="spark.driver.memory",
+                label="Driver Memory",
+                data_type=DataType.STRING,
+                ui_input_type=UiInputType.TEXT,
+                current_value="1g",
+                default_value="1g",
+                is_required=True
+            ),
+            "spark.sql.shuffle.partitions": ConfigOption(
+                id="spark.sql.shuffle.partitions",
+                label="Shuffle Partitions",
+                data_type=DataType.INTEGER,
+                ui_input_type=UiInputType.TEXT,
+                current_value=200,
+                default_value=200,
+                is_required=False
+            )
+        }
 
     def get_session(self) -> SparkSession:
         if self._session is None:
-            self._session = (
+            builder = (
                 SparkSession.builder
                 .appName(self.app_name)
                 .master("local[*]")
@@ -20,6 +51,28 @@ class LocalSparkProvider(SparkProvider):
                 .config("spark.sql.catalog.user", "org.apache.iceberg.spark.SparkCatalog")
                 .config("spark.sql.catalog.user.type", "hadoop")
                 .config("spark.sql.catalog.user.warehouse", "warehouse")
-                .getOrCreate()
             )
+
+            # Apply dynamic configs
+            for config_id, config_opt in self._configs.items():
+                if config_opt.current_value is not None:
+                    builder = builder.config(config_id, config_opt.current_value)
+
+            self._session = builder.getOrCreate()
         return self._session
+
+    def get_configs(self) -> List[ConfigOption]:
+        return list(self._configs.values())
+
+    def set_configs(self, configs: Dict[str, Any]) -> None:
+        restart_needed = False
+        for config_id, value in configs.items():
+            if config_id in self._configs:
+                if self._configs[config_id].current_value != value:
+                    self._configs[config_id].current_value = value
+                    # In a real Spark environment, most configs require restart if session exists
+                    restart_needed = True
+
+        if restart_needed and self._session is not None:
+            self._session.stop()
+            self._session = None

--- a/secondmate/providers/spark_interface.py
+++ b/secondmate/providers/spark_interface.py
@@ -1,7 +1,16 @@
-from typing import Protocol
+from typing import Protocol, List, Dict, Any
 from pyspark.sql import SparkSession
+from secondmate.models import ConfigOption
 
 class SparkProvider(Protocol):
     def get_session(self) -> SparkSession:
         """Get or create a SparkSession."""
+        ...
+
+    def get_configs(self) -> List[ConfigOption]:
+        """Return the current configurations."""
+        ...
+
+    def set_configs(self, configs: Dict[str, Any]) -> None:
+        """Update the configurations."""
         ...

--- a/src/components/Editor/ConfigModal.module.css
+++ b/src/components/Editor/ConfigModal.module.css
@@ -1,0 +1,194 @@
+.modalOverlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.7);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    backdrop-filter: blur(4px);
+}
+
+.modal {
+    background: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 8px;
+    width: 500px;
+    max-width: 90%;
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.5);
+    color: #f8fafc;
+}
+
+.header {
+    padding: 16px 20px;
+    border-bottom: 1px solid #334155;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.header h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+
+.closeButton {
+    background: transparent;
+    border: none;
+    color: #94a3b8;
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.closeButton:hover {
+    background: #334155;
+    color: #f8fafc;
+}
+
+.body {
+    padding: 20px;
+    overflow-y: auto;
+    flex: 1;
+}
+
+.errorBanner {
+    background: #450a0a;
+    border: 1px solid #991b1b;
+    color: #fecaca;
+    padding: 12px;
+    border-radius: 6px;
+    margin-bottom: 20px;
+    font-size: 0.875rem;
+}
+
+.formGroup {
+    margin-bottom: 20px;
+}
+
+.formGroup label {
+    display: block;
+    margin-bottom: 8px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: #94a3b8;
+}
+
+.required {
+    color: #f87171;
+    margin-left: 4px;
+}
+
+.input, .select {
+    width: 100%;
+    background: #0f172a;
+    border: 1px solid #334155;
+    border-radius: 4px;
+    padding: 8px 12px;
+    color: #f8fafc;
+    font-size: 0.875rem;
+}
+
+.input:focus, .select:focus {
+    outline: none;
+    border-color: #38bdf8;
+    box-shadow: 0 0 0 1px #38bdf8;
+}
+
+.radioGroup {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.radioOption {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    font-size: 0.875rem;
+}
+
+.toggleContainer {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    cursor: pointer;
+}
+
+.footer {
+    padding: 16px 20px;
+    border-top: 1px solid #334155;
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+}
+
+.cancelButton {
+    background: transparent;
+    border: 1px solid #334155;
+    color: #f8fafc;
+    padding: 8px 16px;
+    border-radius: 4px;
+    font-size: 0.875rem;
+    cursor: pointer;
+}
+
+.cancelButton:hover {
+    background: #334155;
+}
+
+.saveButton {
+    background: #0ea5e9;
+    border: 1px solid #0ea5e9;
+    color: white;
+    padding: 8px 16px;
+    border-radius: 4px;
+    font-size: 0.875rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.saveButton:hover {
+    background: #0284c7;
+}
+
+.saveButton:disabled {
+    background: #334155;
+    border-color: #334155;
+    color: #64748b;
+    cursor: not-allowed;
+}
+
+.loadingOverlay {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    margin: 20px 0;
+}
+
+.spinner {
+    width: 24px;
+    height: 24px;
+    border: 3px solid rgba(56, 189, 248, 0.3);
+    border-top-color: #38bdf8;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}

--- a/src/components/Editor/ConfigModal.tsx
+++ b/src/components/Editor/ConfigModal.tsx
@@ -1,0 +1,164 @@
+import React, { useState, useEffect } from 'react';
+import { X, Save } from 'lucide-react';
+import { api, type ConfigOption } from '../../services/api';
+import styles from './ConfigModal.module.css';
+
+interface ConfigModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    configs: ConfigOption[];
+    onSaved: () => void;
+}
+
+export const ConfigModal: React.FC<ConfigModalProps> = ({ isOpen, onClose, configs, onSaved }) => {
+    const [values, setValues] = useState<Record<string, any>>({});
+    const [isSaving, setIsSaving] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (isOpen) {
+            const initialValues: Record<string, any> = {};
+            configs.forEach(c => {
+                initialValues[c.id] = c.current_value ?? c.default_value ?? '';
+            });
+            setValues(initialValues);
+            setError(null);
+        }
+    }, [isOpen, configs]);
+
+    if (!isOpen) return null;
+
+    const handleSave = async () => {
+        setIsSaving(true);
+        setError(null);
+        try {
+            await api.saveConfigs(values);
+            onSaved();
+            onClose();
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'An error occurred while saving configurations');
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    const handleChange = (id: string, value: any) => {
+        setValues(prev => ({ ...prev, [id]: value }));
+    };
+
+    const renderInput = (config: ConfigOption) => {
+        const val = values[config.id];
+
+        switch (config.ui_input_type) {
+            case 'select':
+                return (
+                    <select
+                        className={styles.select}
+                        value={val}
+                        onChange={(e) => handleChange(config.id, e.target.value)}
+                    >
+                        {config.options?.map(opt => (
+                            <option key={opt.value} value={opt.value}>{opt.label}</option>
+                        ))}
+                    </select>
+                );
+            case 'radio':
+                return (
+                    <div className={styles.radioGroup}>
+                        {config.options?.map(opt => (
+                            <label key={opt.value} className={styles.radioOption}>
+                                <input
+                                    type="radio"
+                                    name={config.id}
+                                    value={opt.value}
+                                    checked={val === opt.value}
+                                    onChange={() => handleChange(config.id, opt.value)}
+                                />
+                                {opt.label}
+                            </label>
+                        ))}
+                    </div>
+                );
+            case 'toggle':
+                return (
+                    <label className={styles.toggleContainer}>
+                        <input
+                            type="checkbox"
+                            checked={!!val}
+                            onChange={(e) => handleChange(config.id, e.target.checked)}
+                        />
+                        <span>{val ? 'Enabled' : 'Disabled'}</span>
+                    </label>
+                );
+            case 'text':
+            default:
+                return (
+                    <input
+                        className={styles.input}
+                        type={config.data_type === 'integer' ? 'number' : 'text'}
+                        value={val}
+                        onChange={(e) => {
+                            const v = config.data_type === 'integer' ? parseInt(e.target.value, 10) : e.target.value;
+                            handleChange(config.id, isNaN(v as any) ? e.target.value : v);
+                        }}
+                    />
+                );
+        }
+    };
+
+    return (
+        <div className={styles.modalOverlay} onClick={onClose}>
+            <div className={styles.modal} onClick={e => e.stopPropagation()}>
+                <div className={styles.header}>
+                    <h2>Spark Configuration</h2>
+                    <button className={styles.closeButton} onClick={onClose}>
+                        <X size={20} />
+                    </button>
+                </div>
+                <div className={styles.body}>
+                    {error && (
+                        <div className={styles.errorBanner}>
+                            {error}
+                        </div>
+                    )}
+
+                    {isSaving ? (
+                        <div className={styles.loadingOverlay}>
+                            <div className={styles.spinner} />
+                            <p>Settings are being updated...</p>
+                        </div>
+                    ) : (
+                        <div className={styles.form}>
+                            {configs.map(config => (
+                                <div key={config.id} className={styles.formGroup}>
+                                    <label>
+                                        {config.label}
+                                        {config.is_required && <span className={styles.required}>*</span>}
+                                    </label>
+                                    {renderInput(config)}
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </div>
+                <div className={styles.footer}>
+                    <button
+                        className={styles.cancelButton}
+                        onClick={onClose}
+                        disabled={isSaving}
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        className={styles.saveButton}
+                        onClick={handleSave}
+                        disabled={isSaving}
+                    >
+                        <Save size={16} />
+                        Save
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/components/Layout/Workspace.module.css
+++ b/src/components/Layout/Workspace.module.css
@@ -33,6 +33,36 @@
     background-color: #047857;
 }
 
+.runButton:disabled {
+    background-color: #334155;
+    color: #64748b;
+    cursor: not-allowed;
+}
+
+.runButtonWarning {
+    background-color: #334155;
+    color: #94a3b8;
+    border: 1px solid #eab308;
+}
+
+.configButton {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--bg-tertiary);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    padding: 6px;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.configButton:hover {
+    background-color: var(--bg-secondary);
+    border-color: var(--accent-primary);
+}
+
 .historyToggleButton {
     display: flex;
     align-items: center;

--- a/src/components/Layout/Workspace.tsx
+++ b/src/components/Layout/Workspace.tsx
@@ -1,15 +1,16 @@
 // Workspace.tsx
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle, type ImperativePanelHandle } from 'react-resizable-panels';
 import { SqlEditor } from '../Editor/SqlEditor';
 import { DataGrid } from '../Results/DataGrid';
 import { JsonView } from '../Results/JsonView';
 import { SteamboatLoader } from '../SteamboatLoader';
-import { Play, Table, FileJson, History } from 'lucide-react';
+import { Play, Table, FileJson, History, Settings, AlertTriangle } from 'lucide-react';
 import styles from './Workspace.module.css';
-import { api, type QueryResult } from '../../services/api';
+import { api, type QueryResult, type ConfigOption } from '../../services/api';
 import { useQueryHistory } from '../../hooks/useQueryHistory';
 import { QueryHistory } from '../History/QueryHistory';
+import { ConfigModal } from '../Editor/ConfigModal';
 
 export const Workspace: React.FC = () => {
     const [query, setQuery] = useState('-- Write your SparkSQL here\nSELECT * FROM user.sales.transactions LIMIT 100;');
@@ -19,8 +20,28 @@ export const Workspace: React.FC = () => {
     const [viewMode, setViewMode] = useState<'table' | 'json'>('table');
     const [isHistoryOpen, setIsHistoryOpen] = useState(false);
 
+    const [configs, setConfigs] = useState<ConfigOption[]>([]);
+    const [isConfigModalOpen, setIsConfigModalOpen] = useState(false);
+
     const historyPanelRef = useRef<ImperativePanelHandle>(null);
     const { history, addEntry, clearHistory } = useQueryHistory();
+
+    const fetchConfigs = async () => {
+        try {
+            const data = await api.getConfigs();
+            setConfigs(data);
+        } catch (err) {
+            console.error('Failed to fetch configs', err);
+        }
+    };
+
+    useEffect(() => {
+        fetchConfigs();
+    }, []);
+
+    const missingRequiredConfigs = configs.filter(c =>
+        c.is_required && (c.current_value === null || c.current_value === '')
+    );
 
     const handleRunQuery = async () => {
         if (!query.trim()) return;
@@ -56,13 +77,28 @@ export const Workspace: React.FC = () => {
         <div className={styles.workspace}>
             <div className={styles.toolbar}>
                 <button
-                    className={`${styles.runButton} ${loading ? 'opacity-50 cursor-not-allowed' : ''}`}
+                    className={`${styles.runButton} ${missingRequiredConfigs.length > 0 ? styles.runButtonWarning : ''}`}
                     onClick={handleRunQuery}
-                    disabled={loading}
+                    disabled={loading || missingRequiredConfigs.length > 0}
+                    title={missingRequiredConfigs.length > 0 ? "Missing required configurations. Please update settings before running." : ""}
                 >
-                    <Play size={14} fill="currentColor" />
+                    {missingRequiredConfigs.length > 0 ? (
+                        <AlertTriangle size={14} className="text-yellow-500" />
+                    ) : (
+                        <Play size={14} fill="currentColor" />
+                    )}
                     <span>{loading ? 'Running...' : 'Run'}</span>
                 </button>
+
+                {configs.length > 0 && (
+                    <button
+                        className={styles.configButton}
+                        onClick={() => setIsConfigModalOpen(true)}
+                        title="Configure Spark Settings"
+                    >
+                        <Settings size={14} />
+                    </button>
+                )}
 
                 <button
                     className={`${styles.historyToggleButton} ${isHistoryOpen ? styles.historyToggleButtonActive : ''}`}
@@ -73,6 +109,13 @@ export const Workspace: React.FC = () => {
                     <span>History</span>
                 </button>
             </div>
+
+            <ConfigModal
+                isOpen={isConfigModalOpen}
+                onClose={() => setIsConfigModalOpen(false)}
+                configs={configs}
+                onSaved={fetchConfigs}
+            />
 
             <div className={styles.content}>
                 <PanelGroup direction="horizontal">

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -16,6 +16,25 @@ export interface SystemInfo {
     python_version: string;
 }
 
+export type DataType = 'string' | 'integer' | 'boolean';
+export type UiInputType = 'text' | 'select' | 'radio' | 'toggle';
+
+export interface ConfigOptionItem {
+    label: string;
+    value: any;
+}
+
+export interface ConfigOption {
+    id: string;
+    label: string;
+    data_type: DataType;
+    ui_input_type: UiInputType;
+    current_value: any | null;
+    default_value: any | null;
+    options: ConfigOptionItem[] | null;
+    is_required: boolean;
+}
+
 declare global {
     interface Window {
         SECONDMATE_CONFIG?: {
@@ -78,6 +97,24 @@ export const api = {
         const response = await fetch(`${API_BASE_URL}/catalogs/${catalogName}/namespaces/${namespace}/tables/${tableName}/overview`);
         if (!response.ok) throw new Error('Failed to fetch table overview');
         return await response.json();
+    },
+
+    getConfigs: async (): Promise<ConfigOption[]> => {
+        const response = await fetch(`${API_BASE_URL}/configs`);
+        if (!response.ok) throw new Error('Failed to fetch configs');
+        return await response.json();
+    },
+
+    saveConfigs: async (configs: Record<string, any>): Promise<void> => {
+        const response = await fetch(`${API_BASE_URL}/configs`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(configs)
+        });
+        if (!response.ok) {
+            const errorData = await response.json().catch(() => ({}));
+            throw new Error(errorData.detail || 'Failed to save configs');
+        }
     }
 };
 

--- a/tests/test_spark_config.py
+++ b/tests/test_spark_config.py
@@ -1,0 +1,47 @@
+import pytest
+from fastapi.testclient import TestClient
+from secondmate.main import app
+from secondmate.dependencies import get_spark_provider
+from secondmate.providers.local_spark import LocalSparkProvider
+
+client = TestClient(app)
+
+def test_get_configs():
+    response = client.get("/api/configs")
+    assert response.status_code == 200
+    configs = response.json()
+    assert len(configs) > 0
+    ids = [c["id"] for c in configs]
+    assert "spark.executor.memory" in ids
+    assert "spark.driver.memory" in ids
+
+def test_set_configs():
+    new_configs = {"spark.executor.memory": "2g"}
+    response = client.post("/api/configs", json=new_configs)
+    assert response.status_code == 200
+
+    response = client.get("/api/configs")
+    configs = response.json()
+    exec_mem = next(c for c in configs if c["id"] == "spark.executor.memory")
+    assert exec_mem["current_value"] == "2g"
+
+def test_execute_query_validation_failure():
+    # Set a required config to empty
+    client.post("/api/configs", json={"spark.executor.memory": ""})
+
+    # We should NOT call provider.get_session() here because it would try to start spark with invalid config
+    # The validation happens in execute_query before get_spark_session dependency is even resolved?
+    # Actually Depends(get_spark_session) might be resolved first.
+
+    response = client.post("/api/query/execute", json={"query": "SELECT 1"})
+    assert response.status_code == 400
+    assert "Required configuration" in response.json()["detail"]
+
+def test_execute_query_validation_success():
+    # Set required configs to valid values
+    client.post("/api/configs", json={"spark.executor.memory": "1g", "spark.driver.memory": "1g"})
+
+    response = client.post("/api/query/execute", json={"query": "SELECT 1"})
+    # It might fail because of spark session not being available in test env,
+    # but it shouldn't be a 400 validation error.
+    assert response.status_code != 400


### PR DESCRIPTION
This change introduces a dynamic configuration system that allows Spark Providers to expose customizable settings to the UI.

Key changes:
- Backend: Defined Pydantic models for configuration options in `secondmate/models.py`.
- Backend: Updated `SparkProvider` interface and `LocalSparkProvider` to support getting and setting configurations, including automatic SparkSession restarts when necessary.
- Backend: Implemented `/api/configs` endpoints and added server-side validation to `/api/query/execute` to ensure all required configurations are set.
- Frontend: Added `ConfigOption` interfaces and API methods.
- Frontend: Created a dynamic `ConfigModal` component that supports various input types (text, select, radio, toggle).
- Frontend: Integrated the configuration gear icon into the Workspace and implemented logic to disable the 'Run' button with a warning tooltip when required configurations are missing.
- Testing: Added `tests/test_spark_config.py` for backend validation and used Playwright for visual verification of the UI components and states.

Fixes #31

---
*PR created automatically by Jules for task [4678932381826584582](https://jules.google.com/task/4678932381826584582) started by @Cbeaucl*