### PR TITLE
feat(ui): add scroll wrappers to TableOverview datagrids

### DIFF
--- a/src/components/Layout/TableOverview.module.css
+++ b/src/components/Layout/TableOverview.module.css
@@ -103,6 +103,13 @@
     overflow: hidden;
 }
 
+.gridWrapper {
+    height: 300px;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    overflow: auto;
+}
+
 .emptyText {
     color: var(--text-muted);
     font-style: italic;

--- a/src/components/Layout/TableOverview.tsx
+++ b/src/components/Layout/TableOverview.tsx
@@ -107,7 +107,9 @@ export const TableOverview: React.FC<TableOverviewProps> = ({ catalog, namespace
                     <section className={styles.section}>
                         <h2>Table Properties</h2>
                         {properties.length > 0 ? (
-                            <DataGrid columns={getColumns(properties)} data={properties} />
+                            <div className={styles.gridWrapper}>
+                                <DataGrid columns={getColumns(properties)} data={properties} />
+                            </div>
                         ) : (
                             <p className={styles.emptyText}>No properties found.</p>
                         )}
@@ -116,7 +118,9 @@ export const TableOverview: React.FC<TableOverviewProps> = ({ catalog, namespace
                     <section className={styles.section}>
                         <h2>Iceberg Snapshots</h2>
                         {snapshots.length > 0 ? (
-                            <DataGrid columns={getColumns(snapshots)} data={snapshots} />
+                            <div className={styles.gridWrapper}>
+                                <DataGrid columns={getColumns(snapshots)} data={snapshots} />
+                            </div>
                         ) : (
                             <p className={styles.emptyText}>No snapshots found.</p>
                         )}
@@ -125,7 +129,9 @@ export const TableOverview: React.FC<TableOverviewProps> = ({ catalog, namespace
                     <section className={styles.section}>
                         <h2>Iceberg Partitions</h2>
                         {flattenedPartitions.length > 0 ? (
-                            <DataGrid columns={getColumns(flattenedPartitions)} data={flattenedPartitions} />
+                            <div className={styles.gridWrapper}>
+                                <DataGrid columns={getColumns(flattenedPartitions)} data={flattenedPartitions} />
+                            </div>
                         ) : (
                             <p className={styles.emptyText}>No partitions found.</p>
                         )}
@@ -134,7 +140,9 @@ export const TableOverview: React.FC<TableOverviewProps> = ({ catalog, namespace
                     <section className={styles.section}>
                         <h2>Iceberg Files</h2>
                         {files.length > 0 ? (
-                            <DataGrid columns={getColumns(files)} data={files} />
+                            <div className={styles.gridWrapper}>
+                                <DataGrid columns={getColumns(files)} data={files} />
+                            </div>
                         ) : (
                             <p className={styles.emptyText}>No files found.</p>
                         )}


### PR DESCRIPTION
Added `.gridWrapper` class to TableOverview modules with max height 300px and overflow auto to allow inner datagrids to scroll rather than stretch the entire modal.

---
*PR created automatically by Jules for task [5565805263916158145](https://jules.google.com/task/5565805263916158145) started by @Cbeaucl*