### PR TITLE
Support View Rendering and Distinctions

### DIFF
--- a/secondmate/main.py
+++ b/secondmate/main.py
@@ -101,14 +101,27 @@ def get_namespaces(catalog_name: str, spark: SparkSession = Depends(get_spark_se
 
 @router.get("/catalogs/{catalog_name}/namespaces/{namespace}/tables")
 def get_tables(catalog_name: str, namespace: str, spark: SparkSession = Depends(get_spark_session)):
-    """List tables in a specific namespace."""
+    """List tables and views in a specific namespace."""
     validate_identifier(catalog_name)
     validate_identifier(namespace)
     try:
-        df = spark.sql(f"SHOW TABLES IN {catalog_name}.{namespace}")
-        # Columns: 'namespace', 'tableName', 'isTemporary'
-        tables = [row.tableName for row in df.collect()]
-        return {"tables": tables}
+        items_dict = {}
+
+        # 1. Get Tables (which also includes views, but we'll flag them as tables initially)
+        df_tables = spark.sql(f"SHOW TABLES IN {catalog_name}.{namespace}")
+        for row in df_tables.collect():
+            items_dict[row.tableName] = "table"
+
+        # 2. Get Views (to override the type of views)
+        try:
+            df_views = spark.sql(f"SHOW VIEWS IN {catalog_name}.{namespace}")
+            for row in df_views.collect():
+                items_dict[row.viewName] = "view"
+        except Exception as e:
+            logger.warning(f"Failed to fetch views for {catalog_name}.{namespace}: {e}")
+
+        items = [{"name": name, "type": type} for name, type in items_dict.items()]
+        return {"items": items}
     except Exception:
         logger.error(f"Error retrieving tables for {catalog_name}.{namespace}", exc_info=True)
         return {"tables": [], "error": "Unable to retrieve tables."}

--- a/secondmate/main.py
+++ b/secondmate/main.py
@@ -118,7 +118,7 @@ def get_tables(catalog_name: str, namespace: str, spark: SparkSession = Depends(
             for row in df_views.collect():
                 items_dict[row.viewName] = "view"
         except Exception as e:
-            logger.warning(f"Failed to fetch views for {catalog_name}.{namespace}: {e}")
+            logger.debug(f"Views not supported for {catalog_name}.{namespace}: {e}")
 
         items = [{"name": name, "type": type} for name, type in items_dict.items()]
         return {"items": items}
@@ -182,17 +182,27 @@ def search_catalog(q: str, spark: SparkSession = Depends(get_spark_session)):
                     
                     try:
                         # 3. Search Tables within Namespace
+                        items_dict = {}
                         df_tables = spark.sql(f"SHOW TABLES IN {cat}.{ns}")
-                        tables = [row.tableName for row in df_tables.collect()]
-                        
-                        for table in tables:
-                            if query in table.lower():
+                        for row in df_tables.collect():
+                            items_dict[row.tableName] = "table"
+
+                        # 4. Search Views within Namespace (override type)
+                        try:
+                            df_views = spark.sql(f"SHOW VIEWS IN {cat}.{ns}")
+                            for row in df_views.collect():
+                                items_dict[row.viewName] = "view"
+                        except Exception as e:
+                            logger.debug(f"Views not supported for {cat}.{ns}: {e}")
+
+                        for name, item_type in items_dict.items():
+                            if query in name.lower():
                                 results.append({
-                                    "type": "table", 
+                                    "type": item_type, 
                                     "catalog": cat, 
                                     "namespace": ns, 
-                                    "table": table,
-                                    "name": table
+                                    "table": name,
+                                    "name": name
                                 })
                     except Exception:
                         continue # Ignore individual failures

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Database, Table, Folder, Search, Loader2, X, Check } from 'lucide-react';
+import { Database, Table, Folder, Search, Loader2, X, Check, Eye } from 'lucide-react';
 import styles from './Sidebar.module.css';
 import { api } from '../../services/api';
 import { TreeNode } from './TreeNode';
@@ -15,7 +15,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ onTableOverview, onShowDdl }) 
     const [expandedCatalogs, setExpandedCatalogs] = useState<Record<string, boolean>>({});
     const [namespaces, setNamespaces] = useState<Record<string, string[]>>({});
     const [expandedNamespaces, setExpandedNamespaces] = useState<Record<string, boolean>>({}); // key: catalog.namespace
-    const [tables, setTables] = useState<Record<string, string[]>>({}); // key: catalog.namespace
+    const [tables, setTables] = useState<Record<string, {name: string, type: 'table' | 'view'}[]>>({}); // key: catalog.namespace
     const [loading, setLoading] = useState<Record<string, boolean>>({}); // key: node id
 
     // Tab State
@@ -28,7 +28,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ onTableOverview, onShowDdl }) 
     const [copiedNodeInfo, setCopiedNodeInfo] = useState<string | null>(null);
 
     const handleCopySearchNode = (item: any) => {
-        if (item.type === 'table') {
+        if (item.type === 'table' || item.type === 'view') {
             const fullName = `${item.catalog}.${item.namespace}.${item.table}`;
             navigator.clipboard.writeText(fullName);
             setCopiedNodeInfo(fullName);
@@ -167,11 +167,11 @@ export const Sidebar: React.FC<SidebarProps> = ({ onTableOverview, onShowDdl }) 
                                     isLoading={loading[`${catalog}.${ns}`]}
                                     onToggle={() => toggleNamespace(catalog, ns)}
                                 >
-                                    {tables[`${catalog}.${ns}`]?.map(table => (
+                                    {tables[`${catalog}.${ns}`]?.map(tableObj => (
                                         <TreeNode
-                                            key={table}
-                                            label={table}
-                                            type="table"
+                                            key={tableObj.name}
+                                            label={tableObj.name}
+                                            type={tableObj.type as 'table' | 'view'}
                                             catalog={catalog}
                                             namespace={ns}
                                             onTableOverview={onTableOverview}
@@ -195,34 +195,39 @@ export const Sidebar: React.FC<SidebarProps> = ({ onTableOverview, onShowDdl }) 
                             </div>
                         )}
                         {!isSearching && searchResults.map((item, idx) => {
-                            const fullName = item.type === 'table' ? `${item.catalog}.${item.namespace}.${item.table}` : '';
-                            const isCopied = copiedNodeInfo === fullName && item.type === 'table';
+                            const isTableOrView = item.type === 'table' || item.type === 'view';
+                            const fullName = isTableOrView ? `${item.catalog}.${item.namespace}.${item.table}` : '';
+                            const isCopied = copiedNodeInfo === fullName && isTableOrView;
 
                             return (
                                 <div
                                     key={idx}
                                     className={styles.treeRow}
-                                    style={{ paddingLeft: '12px', cursor: item.type === 'table' ? 'pointer' : 'default' }}
-                                    onClick={item.type === 'table' ? () => handleCopySearchNode(item) : undefined}
-                                    title={item.type === 'table' ? "Click to copy table name" : undefined}
+                                    style={{ paddingLeft: '12px', cursor: isTableOrView ? 'pointer' : 'default' }}
+                                    onClick={isTableOrView ? () => handleCopySearchNode(item) : undefined}
+                                    title={isTableOrView ? "Click to copy name" : undefined}
                                 >
                                     {item.type === 'catalog' && <Database size={14} className={styles.icon} color="#38bdf8" />}
                                     {item.type === 'namespace' && <Folder size={14} className={styles.icon} color="#fbbf24" />}
                                     {item.type === 'table' && (
                                         isCopied ? <Check size={14} className={styles.icon} color="#10b981" /> : <Table size={14} className={styles.icon} color="#a78bfa" />
                                     )}
+                                    {item.type === 'view' && (
+                                        isCopied ? <Check size={14} className={styles.icon} color="#10b981" /> : <Eye size={14} className={styles.icon} color="#a78bfa" />
+                                    )}
 
                                     <span className="truncate" style={{ marginLeft: '6px' }}>
                                         {item.type === 'catalog' && item.catalog}
                                         {item.type === 'namespace' && `${item.catalog}.${item.namespace}`}
-                                        {item.type === 'table' && fullName}
+                                        {isTableOrView && fullName}
                                     </span>
 
-                                    {item.type === 'table' && onTableOverview && onShowDdl && (
+                                    {isTableOrView && onTableOverview && onShowDdl && (
                                         <TableMenu
                                             catalog={item.catalog}
                                             namespace={item.namespace}
                                             table={item.table}
+                                            isView={item.type === 'view'}
                                             onTableOverview={onTableOverview}
                                             onShowDdl={onShowDdl}
                                         />

--- a/src/components/Layout/TableMenu.tsx
+++ b/src/components/Layout/TableMenu.tsx
@@ -3,6 +3,7 @@ import { MoreVertical, FileText, Code } from 'lucide-react';
 import styles from './Sidebar.module.css';
 
 export interface TableMenuProps {
+    isView?: boolean;
     catalog: string;
     namespace: string;
     table: string;
@@ -10,7 +11,8 @@ export interface TableMenuProps {
     onShowDdl: (catalog: string, namespace: string, table: string) => void;
 }
 
-export const TableMenu: React.FC<TableMenuProps> = ({ catalog, namespace, table, onTableOverview, onShowDdl }) => {
+export const TableMenu: React.FC<TableMenuProps> = ({ catalog, namespace, table,
+    isView, onTableOverview, onShowDdl }) => {
     const [menuOpen, setMenuOpen] = useState<{ x: number, y: number } | null>(null);
 
     const handleMoreClick = (e: React.MouseEvent) => {
@@ -36,16 +38,18 @@ export const TableMenu: React.FC<TableMenuProps> = ({ catalog, namespace, table,
                     style={{ top: menuOpen.y, left: menuOpen.x }}
                     onClick={(e) => e.stopPropagation()}
                 >
-                    <div
-                        className={styles.menuItem}
-                        onClick={() => {
-                            onTableOverview(catalog, namespace, table);
-                            setMenuOpen(null);
-                        }}
-                    >
-                        <FileText size={14} />
-                        <span>Table Overview</span>
-                    </div>
+                    {!isView && (
+                        <div
+                            className={styles.menuItem}
+                            onClick={() => {
+                                onTableOverview(catalog, namespace, table);
+                                setMenuOpen(null);
+                            }}
+                        >
+                            <FileText size={14} />
+                            <span>Table Overview</span>
+                        </div>
+                    )}
                     <div
                         className={styles.menuItem}
                         onClick={() => {

--- a/src/components/Layout/TreeNode.tsx
+++ b/src/components/Layout/TreeNode.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
-import { Database, Table, Folder, ChevronRight, ChevronDown, Loader2, Check } from 'lucide-react';
+import { Database, Table, Folder, ChevronRight, ChevronDown, Loader2, Check, Eye } from 'lucide-react';
 import styles from './Sidebar.module.css';
 import { TableMenu } from './TableMenu';
 
 export interface TreeNodeProps {
     label: string;
-    type: 'catalog' | 'namespace' | 'table';
+    type: 'catalog' | 'namespace' | 'table' | 'view';
     catalog?: string;
     namespace?: string;
     children?: React.ReactNode;
@@ -33,7 +33,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
     const [copied, setCopied] = useState(false);
 
     const handleCopy = (e: React.MouseEvent) => {
-        if (type === 'table' && catalog && namespace) {
+        if ((type === 'table' || type === 'view') && catalog && namespace) {
             e.stopPropagation();
             const fullName = `${catalog}.${namespace}.${label}`;
             navigator.clipboard.writeText(fullName);
@@ -44,7 +44,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
         }
     };
 
-    const Icon = type === 'catalog' ? Database : type === 'namespace' ? Folder : (copied ? Check : Table);
+    const Icon = type === 'catalog' ? Database : type === 'namespace' ? Folder : type === 'view' ? Eye : (copied ? Check : Table);
     const color = type === 'catalog' ? '#38bdf8' : type === 'namespace' ? '#fbbf24' : (copied ? '#10b981' : '#a78bfa');
     const showChildren = forceExpand || isExpanded;
 
@@ -52,24 +52,25 @@ export const TreeNode: React.FC<TreeNodeProps> = ({
         <div className={styles.treeItem}>
             <div
                 className={styles.treeRow}
-                onClick={type === 'table' ? handleCopy : onToggle}
+                onClick={(type === 'table' || type === 'view') ? handleCopy : onToggle}
                 style={{ cursor: 'pointer' }}
-                title={type === 'table' ? "Click to copy table name" : undefined}
+                title={(type === 'table' || type === 'view') ? "Click to copy name" : undefined}
             >
-                {type !== 'table' && (
+                {(type !== 'table' && type !== 'view') && (
                     <div style={{ width: 16, display: 'flex', alignItems: 'center' }}>
                         {isLoading ? <Loader2 size={12} className={styles.spinner} /> :
                             showChildren ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
                     </div>
                 )}
-                {type === 'table' && <div style={{ width: 16 }} />}
+                {(type === 'table' || type === 'view') && <div style={{ width: 16 }} />}
                 <Icon size={14} className={styles.icon} color={color} />
                 <span className="truncate">{label}</span>
-                {type === 'table' && onTableOverview && onShowDdl && catalog && namespace && (
+                {(type === 'table' || type === 'view') && onTableOverview && onShowDdl && catalog && namespace && (
                     <TableMenu
                         catalog={catalog}
                         namespace={namespace}
                         table={label}
+                        isView={type === 'view'}
                         onTableOverview={onTableOverview}
                         onShowDdl={onShowDdl}
                     />

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -73,11 +73,11 @@ export const api = {
         return data.namespaces;
     },
 
-    getTables: async (catalogName: string, namespace: string): Promise<string[]> => {
+    getTables: async (catalogName: string, namespace: string): Promise<{name: string, type: 'table' | 'view'}[]> => {
         const response = await fetch(`${API_BASE_URL}/catalogs/${catalogName}/namespaces/${namespace}/tables`);
         if (!response.ok) throw new Error('Failed to fetch tables');
         const data = await response.json();
-        return data.tables;
+        return data.items;
     },
 
     searchCatalog: async (query: string): Promise<any[]> => {


### PR DESCRIPTION
This commit adds full support for fetching and rendering views alongside tables in the data catalog interface.

- Modified backend `get_tables` and `search_catalog` to fetch views via `SHOW VIEWS` in Spark and deduplicate them against the `SHOW TABLES` output.
- Updated the API to return an array of objects (`{"items": [{"name": "table_name", "type": "table"}]}`) instead of an array of strings.
- Added support for the `view` type to frontend API models, `TreeNode.tsx`, and `TableMenu.tsx`.
- The `Eye` icon is used to distinguish views from tables.
- The "Table Overview" menu item has been hidden for view nodes.
- Fixed unit test expectations to match the new API response format.

---
*PR created automatically by Jules for task [14977948711367059963](https://jules.google.com/task/14977948711367059963) started by @Cbeaucl*